### PR TITLE
06_textures.md:  Fix top/bottom comment.

### DIFF
--- a/book/src/06_textures.md
+++ b/book/src/06_textures.md
@@ -64,8 +64,8 @@ impl Quad {
     // X    Y    R    G    B                  U    V
       x  , y+h, 1.0, 0.0, 0.0, /* red     */ 0.0, 1.0, /* bottom left */
       x  , y  , 0.0, 1.0, 0.0, /* green   */ 0.0, 0.0, /* top left */
-      x+w, y  , 0.0, 0.0, 1.0, /* blue    */ 1.0, 0.0, /* bottom right */
-      x+w, y+h, 1.0, 0.0, 1.0, /* magenta */ 1.0, 1.0, /* top right */
+      x+w, y  , 0.0, 0.0, 1.0, /* blue    */ 1.0, 0.0, /* top right */
+      x+w, y+h, 1.0, 0.0, 1.0, /* magenta */ 1.0, 1.0, /* bottom right */
     ]
   }
 }


### PR DESCRIPTION
I'm assuming +V/Y is down and -V/Y is up which seems to match the rest of the comments in the next section.

(Per the \#games-and-graphics [community discord discussion](https://discordapp.com/channels/273534239310479360/335502453371961344/611381911994105886) the other day.)